### PR TITLE
Fix pagination: count medication histories by user

### DIFF
--- a/app/Services/MedicationHistoryService.php
+++ b/app/Services/MedicationHistoryService.php
@@ -66,7 +66,7 @@ class MedicationHistoryService extends AppService
 
         $paginator = new MedicationHistoryListResult(
             $medicationHistoryDetailList,
-            $this->medicationHistoryRepository->getCount(),
+            $this->medicationHistoryRepository->getCountByUserId($userId),
             $paginate,
         );
 

--- a/domain/MedicationHistory/MedicationHistoryRepository.php
+++ b/domain/MedicationHistory/MedicationHistoryRepository.php
@@ -14,6 +14,7 @@ interface MedicationHistoryRepository
     public function getPaginator(Paginate $paginate): MedicationHistoryList;
     public function getPaginatorByUserId(Paginate $paginate, UserId $userId): MedicationHistoryList;
     public function getCount(): MedicationHistoryCount;
+    public function getCountByUserId(UserId $userId): MedicationHistoryCount;
     public function getCountMedicationTake(DrugId $drugId): RawPositiveInteger;
     public function create(
         UserId $userId,

--- a/infra/EloquentRepository/MedicationHistoryRepository.php
+++ b/infra/EloquentRepository/MedicationHistoryRepository.php
@@ -72,6 +72,12 @@ class MedicationHistoryRepository implements MedicationHistoryRepositoryInterfac
         return new MedicationHistoryCount($query->count());
     }
 
+    public function getCountByUserId(UserId $userId): MedicationHistoryCount
+    {
+        $query = MedicationHistoryModel::where(['user_id' => $userId->getRawValue()]);
+        return new MedicationHistoryCount($query->count());
+    }
+
     public function getCountMedicationTake(DrugId $drugId): RawPositiveInteger
     {
         return new RawPositiveInteger(


### PR DESCRIPTION
## Summary
- `MedicationHistoryRepository::getCount()` が全ユーザーのレコード数を返していたが、データ取得は `getPaginatorByUserId()` で特定ユーザーのみだったため、`total` / `lastPage` が実際より大きくなり後半のページが空になっていた
- `getCountByUserId(UserId)` メソッドを追加し、サービス層で使用するよう修正

## Test plan
- [ ] 服薬履歴ページで一定ページを超えてもデータが表示されることを確認
- [ ] `lastPage` がそのユーザーのデータ数に基づいて正しく計算されていること
- [ ] 他ユーザーのデータ数が多い場合でも、自分のページネーションが正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)