### PR TITLE
Add medication history delete and date editing

### DIFF
--- a/app/Http/Api/MedicationHistory/Actions/DeleteMedicationHistoryAction.php
+++ b/app/Http/Api/MedicationHistory/Actions/DeleteMedicationHistoryAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\MedicationHistory\Actions;
+
+use App\Http\Api\Common\Responder\ApiErrorResponder;
+use App\Http\Api\Common\Responder\EmptyResponder;
+use App\Http\Controllers\Controller;
+use App\Services\MedicationHistoryService;
+use Domain\MedicationHistory\MedicationHistoryId;
+use OpenApi\Attributes\Delete;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Parameter;
+use OpenApi\Attributes\Response;
+use OpenApi\Attributes\Schema;
+
+#[Delete(
+    path: '/api/medication_histories/{id}',
+    summary: '服薬履歴を削除する',
+    tags: ['MedicationHistory'],
+    parameters: [
+        new Parameter(
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: new Schema(
+                type: 'integer'
+            )
+        )
+    ],
+    responses: [
+        new Response(
+            response: '200',
+            description: 'success',
+            content: new JsonContent(
+                ref: '#/components/schemas/base_responder'
+            )
+        ),
+        new Response(
+            response: '404',
+            description: 'not found',
+            content: new JsonContent(
+                ref: '#/components/schemas/api_error_responder'
+            )
+        ),
+    ]
+)]
+class DeleteMedicationHistoryAction extends Controller
+{
+    public function __construct(private MedicationHistoryService $medicationHistoryService)
+    {
+        parent::__construct();
+    }
+
+    public function __invoke(int $id): EmptyResponder|ApiErrorResponder
+    {
+        $result = $this->medicationHistoryService->delete(new MedicationHistoryId($id));
+
+        if ($result->isFailed()) {
+            return new ApiErrorResponder($result->getError());
+        }
+
+        return new EmptyResponder();
+    }
+}

--- a/app/Http/Api/MedicationHistory/Actions/UpdateMedicationHistoryAction.php
+++ b/app/Http/Api/MedicationHistory/Actions/UpdateMedicationHistoryAction.php
@@ -59,12 +59,14 @@ class UpdateMedicationHistoryAction extends Controller
     {
         $existing = $this->medicationHistoryRepository->get(new MedicationHistoryId($id));
 
+        $medicationDate = $request->getMedicationDate() ?? $existing->getMedicationDate();
+
         $medicationHistory = new MedicationHistory(
             $existing->getId(),
             $existing->getUserId(),
             $existing->getDrugId(),
             $request->getAmount(),
-            $existing->getMedicationDate(),
+            $medicationDate,
             $request->getNote(),
             $existing->getCreatedAt(),
             UpdatedAt::now(),

--- a/app/Http/Api/MedicationHistory/Requests/UpdateMedicationHistoryRequest.php
+++ b/app/Http/Api/MedicationHistory/Requests/UpdateMedicationHistoryRequest.php
@@ -6,6 +6,7 @@ namespace App\Http\Api\MedicationHistory\Requests;
 
 use App\Http\Api\Shered\Request\ApiRequest;
 use Domain\MedicationHistory\Amount;
+use Domain\MedicationHistory\MedicationDate;
 use Domain\MedicationHistory\MedicationNote;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
@@ -15,6 +16,7 @@ use OpenApi\Attributes\Schema;
     properties: [
         new Property(property: 'amount', type: 'number', format: 'double'),
         new Property(property: 'note', type: 'string', nullable: true),
+        new Property(property: 'medication_date', type: 'string', format: 'date-time', nullable: true),
     ]
 )]
 class UpdateMedicationHistoryRequest extends ApiRequest
@@ -29,6 +31,7 @@ class UpdateMedicationHistoryRequest extends ApiRequest
         return [
             'amount' => 'required|numeric',
             'note' => 'nullable|string',
+            'medication_date' => 'nullable|date',
         ];
     }
 
@@ -40,5 +43,14 @@ class UpdateMedicationHistoryRequest extends ApiRequest
     public function getNote(): MedicationNote
     {
         return new MedicationNote($this->input('note'));
+    }
+
+    public function getMedicationDate(): ?MedicationDate
+    {
+        $value = $this->input('medication_date');
+        if (is_null($value)) {
+            return null;
+        }
+        return new MedicationDate($value);
     }
 }

--- a/app/Services/MedicationHistoryService.php
+++ b/app/Services/MedicationHistoryService.php
@@ -110,6 +110,21 @@ class MedicationHistoryService extends AppService
     }
 
     /**
+     * @param MedicationHistoryId $id
+     * @return ServiceResult<null>
+     */
+    public function delete(MedicationHistoryId $id): ServiceResult
+    {
+        try {
+            $this->medicationHistoryDomainService->delete($id);
+
+            return ServiceResult::success(null);
+        } catch (NotFoundException) {
+            return ServiceResult::fail(ServiceError::NotFound);
+        }
+    }
+
+    /**
      * @param DrugId $drugId
      * @param UserId $userId
      * @param Amount $amount

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Api\Drug\Actions\GetDrugAction;
 use App\Http\Api\Drug\Actions\GetDrugListAction;
 use App\Http\Api\Drug\Actions\UpdateDrugAction;
 use App\Http\Api\MedicationHistory\Actions\CreateMedicationHistoryAction;
+use App\Http\Api\MedicationHistory\Actions\DeleteMedicationHistoryAction;
 use App\Http\Api\MedicationHistory\Actions\GetMedicationHistoryAction;
 use App\Http\Api\MedicationHistory\Actions\GetMedicationHistoryListAction;
 use App\Http\Api\MedicationHistory\Actions\UpdateMedicationHistoryAction;
@@ -42,5 +43,6 @@ Route:: group([], function() {
         Route::post('/', CreateMedicationHistoryAction::class)->name('api.medication_histories.create');
         Route::get('/{id}', GetMedicationHistoryAction::class)->name('api.medication_histories.detail');
         Route::put('/{id}', UpdateMedicationHistoryAction::class)->name('api.medication_histories.update');
+        Route::delete('/{id}', DeleteMedicationHistoryAction::class)->name('api.medication_histories.delete');
     });
 });

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -377,6 +377,45 @@
                         "description": "Unauthorized"
                     }
                 }
+            },
+            "delete": {
+                "tags": [
+                    "MedicationHistory"
+                ],
+                "summary": "服薬履歴を削除する",
+                "operationId": "1ad17a3f19538c0535c42eb5fd6295cd",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/base_responder"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api_error_responder"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     },
@@ -724,6 +763,11 @@
                     },
                     "note": {
                         "type": "string",
+                        "nullable": true
+                    },
+                    "medication_date": {
+                        "type": "string",
+                        "format": "date-time",
                         "nullable": true
                     }
                 },


### PR DESCRIPTION
## Summary
- 服薬履歴の削除 API エンドポイント追加 (`DELETE /api/medication_histories/{id}`)
- 服薬履歴更新 API に `medication_date` フィールド追加（服薬日時の編集対応）
- OpenAPI スキーマ更新

## Test plan
- [ ] 服薬履歴の削除が正しく動作すること
- [ ] 服薬日時を指定して更新できること
- [ ] medication_date を null で送信した場合、既存の日時が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)